### PR TITLE
Optimize buffer info

### DIFF
--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -32,7 +32,6 @@ from gtc import gtir_to_oir
 from gtc.common import DataType
 from gtc.cuir import cuir, cuir_codegen, extent_analysis, kernel_fusion, oir_to_cuir
 from gtc.passes.gtir_pipeline import GtirPipeline
-from gtc.passes.oir_optimizations.horizontal_execution_merging import GreedyMerging
 from gtc.passes.oir_optimizations.pruning import NoFieldAccessPruning
 from gtc.passes.oir_pipeline import OirPipeline
 
@@ -49,9 +48,7 @@ class GTCCudaExtGenerator:
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
-        oir = OirPipeline(gtir_to_oir.GTIRToOIR().visit(gtir)).full(
-            skip=[GreedyMerging, NoFieldAccessPruning]
-        )
+        oir = OirPipeline(gtir_to_oir.GTIRToOIR().visit(gtir)).full(skip=[NoFieldAccessPruning])
         cuir = oir_to_cuir.OIRToCUIR().visit(oir)
         cuir = kernel_fusion.FuseKernels().visit(cuir)
         cuir = extent_analysis.ComputeExtents().visit(cuir)

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -38,7 +38,6 @@ from gtc.common import DataType
 from gtc.gtcpp import gtcpp, gtcpp_codegen, oir_to_gtcpp
 from gtc.passes.gtir_pipeline import GtirPipeline
 from gtc.passes.oir_optimizations.caches import FillFlushToLocalKCaches
-from gtc.passes.oir_optimizations.horizontal_execution_merging import GreedyMerging
 from gtc.passes.oir_pipeline import OirPipeline
 
 
@@ -54,9 +53,7 @@ class GTCGTExtGenerator:
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
-        oir = OirPipeline(gtir_to_oir.GTIRToOIR().visit(gtir)).full(
-            skip=[GreedyMerging, FillFlushToLocalKCaches]
-        )
+        oir = OirPipeline(gtir_to_oir.GTIRToOIR().visit(gtir)).full(skip=[FillFlushToLocalKCaches])
         gtcpp = oir_to_gtcpp.OIRToGTCpp().visit(oir)
         implementation = gtcpp_codegen.GTCppCodegen.apply(
             gtcpp, gt_backend_t=self.backend.GT_BACKEND_T

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -472,9 +472,11 @@ class PyExtModuleGenerator(BaseModuleGenerator):
         api_fields = set(field.name for field in definition_ir.api_fields)
         for arg in definition_ir.api_signature:
             if arg.name not in self.args_data.unreferenced:
-                args.append(arg.name)
                 if arg.name in api_fields:
+                    args.append(f"{arg.name}.__array_struct__")
                     args.append("list(_origin_['{}'])".format(arg.name))
+                else:
+                    args.append(f"{arg.name}")
 
         # only generate implementation if any multi_stages are present. e.g. if no statement in the
         # stencil has any effect on the API fields, this may not be the case since they could be

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -38,43 +38,23 @@ static constexpr int MAX_DIM = 3;
 
 namespace {
 
-BufferInfo make_buffer_info(py::object& b) {
-{%- if gt_backend == "cuda" %}
-    py_size_t ndim = static_cast<py_size_t>(b.attr("ndim").cast<int>());
-//    auto shape_tuple = b.attr("shape").cast<std::tuple<int, int, int>>();
-//    std::vector<py_size_t> shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple), std::get<2>(shape_tuple)};
-//    auto strides_tuple = b.attr("strides").cast<std::tuple<int, int, int>>();
-//    std::vector<py_size_t> strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple), std::get<2>(strides_tuple)};
-//    void* ptr =  reinterpret_cast<void*>(b.attr("data").attr("ptr").cast<std::size_t>());
-    py::dict __cuda_array_interface__ = b.attr("__cuda_array_interface__").cast<py::dict>();
-    std::vector<py_size_t> shape;
-    std::vector<py_size_t> strides;
-    if(ndim == 1) {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int>>();
-        shape = {std::get<0>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int>>();
-        strides = {std::get<0>(strides_tuple)};
-    } else if(ndim == 2) {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int, int>>();
-        shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int, int>>();
-        strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple)};
-    } else {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int, int, int>>();
-        shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple), std::get<2>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int, int, int>>();
-        strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple), std::get<2>(strides_tuple)};
-    }
-    void* ptr =  reinterpret_cast<void*>(std::get<0>(__cuda_array_interface__["data"].cast<std::tuple<std::size_t, bool>>()));
-{%- else %}
-    auto buffer_info = static_cast<py::buffer&>(b).request();
-    py_size_t ndim = static_cast<py_size_t>(buffer_info.ndim);
-    std::vector<py_size_t>& shape = buffer_info.shape;
-    std::vector<py_size_t>& strides = buffer_info.strides;
-    void* ptr = static_cast<void*>(buffer_info.ptr);
-{%- endif %}
+// Per Numpy C struct
+// https://numpy.org/doc/stable/reference/c-api/types-and-structures.html#pyarray-type-and-pyarrayobject
+typedef struct {
+    int two;
+    int nd;
+    char typekind;
+    int itemsize;
+    int flags;
+    int64_t *shape;
+    int64_t *strides;
+    void *data;
+    PyObject *descr;
+} PyArrayInterface;
 
-    return BufferInfo{ndim, shape, strides, ptr};
+BufferInfo make_buffer_info(const py::capsule& buffer_as_capsule) {
+    PyArrayInterface* b = buffer_as_capsule.cast<py::capsule>();
+    return BufferInfo{b->nd, b->shape, b->strides, b->data};
 }
 
 void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
@@ -83,7 +63,7 @@ void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
 {%- for field in arg_fields -%}
 {%- if api_name == field.name -%}
                      {{- comma() }}
-                     py::object {{ field.name }}, const std::array<gt::uint_t, {{ field.naxes }}>& {{ field.name }}_origin
+                     const py::capsule& {{ field.name }}_capsule, const std::array<gt::uint_t, {{ field.naxes }}>& {{ field.name }}_origin
 {%- endif -%}
 {%- endfor -%}
 {%- for param in parameters -%}
@@ -101,7 +81,7 @@ void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
     }
 
 {%- for field in arg_fields %}
-    auto bi_{{ field.name }} = make_buffer_info({{ field.name }});
+    auto bi_{{ field.name }} = make_buffer_info({{ field.name }}_capsule);
 {%- endfor %}
 
     {{ stencil_unique_name }}::run(domain,

--- a/src/gt4py/backend/templates/computation.hpp.in
+++ b/src/gt4py/backend/templates/computation.hpp.in
@@ -39,8 +39,8 @@ using py_size_t = std::intptr_t;
 
 struct BufferInfo {
     py_size_t ndim;
-    std::vector<py_size_t> shape;
-    std::vector<py_size_t> strides;
+    py_size_t* shape;
+    py_size_t* strides;
     void* ptr;
 };
 

--- a/src/gtc/dace/oir_to_dace.py
+++ b/src/gtc/dace/oir_to_dace.py
@@ -200,10 +200,13 @@ class BaseOirSDFGBuilder(ABC):
         for interval, access_collection in collections:
             for name in access_collection.write_fields():
                 access_node = self._get_current_sink(name)
-                if (
-                    access_node is None
-                    or access_node in self._get_recent_reads(name, interval)
-                    or access_node in self._get_recent_writes(name, interval)
+                if access_node is None or (
+                    (name not in write_accesses)
+                    and (
+                        access_node in self._get_recent_reads(name, interval)
+                        or access_node in self._get_recent_writes(name, interval)
+                        or nx.has_path(self._state.nx, access_node, node)
+                    )
                 ):
                     write_accesses[name] = self._get_new_sink(name)
                 else:

--- a/src/gtc/passes/oir_dace_optimizations/api.py
+++ b/src/gtc/passes/oir_dace_optimizations/api.py
@@ -26,6 +26,9 @@ def optimize_horizontal_executions(
     stencil: oir.Stencil, transformation: Transformation
 ) -> oir.Stencil:
     sdfg = OirSDFGBuilder().visit(stencil)
+    api_fields = {param.name for param in stencil.params}
     for subgraph in iter_vertical_loop_section_sub_sdfgs(sdfg):
-        subgraph.apply_transformations_repeated(transformation, validate=False)
+        subgraph.apply_transformations_repeated(
+            transformation, validate=False, options=dict(api_fields=api_fields)
+        )
     return dace_to_oir.convert(sdfg)

--- a/src/gtc/passes/oir_dace_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_dace_optimizations/horizontal_execution_merging.py
@@ -29,6 +29,7 @@ import dace
 import dace.subsets
 import networkx as nx
 from dace import SDFGState
+from dace.properties import Property, make_properties
 from dace.sdfg import graph
 from dace.sdfg.utils import node_path_graph
 from dace.transformation.transformation import PatternNode, Transformation
@@ -75,6 +76,22 @@ def offsets_match(
         ij_offsets(left_accesses.read_offsets()), ij_offsets(right_accesses.write_offsets())
     )
     return not conflicting
+
+
+def iteration_space_compatible(
+    left: HorizontalExecutionLibraryNode,
+    right: HorizontalExecutionLibraryNode,
+    api_fields: Set[str],
+):
+
+    if left.iteration_space == right.iteration_space:
+        return True
+
+    for conn_name in set(left.out_connectors) | set(right.out_connectors):
+        name = conn_name[len("OUT_") :]
+        if name in api_fields:
+            return False
+    return True
 
 
 def unwire_access_node(
@@ -151,7 +168,14 @@ def optional_node(pattern_node: PatternNode, sdfg: dace.SDFG) -> Optional[dace.n
 
 
 @dace.registry.autoregister_params(singlestate=True)
+@make_properties
 class GraphMerging(Transformation):
+
+    api_fields = Property(
+        dtype=set,
+        desc="Set of field names that are parameters to the parent stencil",
+    )
+
     left = PatternNode(HorizontalExecutionLibraryNode)
     right = PatternNode(HorizontalExecutionLibraryNode)
     access = PatternNode(dace.nodes.AccessNode)
@@ -170,7 +194,7 @@ class GraphMerging(Transformation):
         graph: SDFGState,
         candidate: Dict[str, dace.nodes.Node],
         expr_index: int,
-        sdfg: Union[dace.SDFG, SDFGState],
+        sdfg: dace.SDFG,
         strict: bool = False,
     ) -> bool:
         left = self.left(sdfg)
@@ -199,7 +223,9 @@ class GraphMerging(Transformation):
         if len(protected_intermediate_names & output_names) > 0:
             return False
 
-        return offsets_match(left, right)
+        return offsets_match(left, right) and iteration_space_compatible(
+            left, right, self.api_fields
+        )
 
     def apply(self, sdfg: dace.SDFG) -> None:
         state = sdfg.node(self.state_id)

--- a/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
@@ -19,67 +19,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from eve import NodeTranslator
 from gtc import common, oir
-from gtc.common import GTCPostconditionError, GTCPreconditionError
 
 from .utils import AccessCollector, symbol_name_creator
-
-
-class GreedyMerging(NodeTranslator):
-    """Merges consecutive horizontal executions if there are no write/read conflicts.
-
-    Preconditions: All vertical loops are non-empty.
-    Postcondition: The number of horizontal executions is equal or smaller than before.
-    """
-
-    def visit_VerticalLoopSection(
-        self, node: oir.VerticalLoopSection, **kwargs: Any
-    ) -> oir.VerticalLoopSection:
-        if not node.horizontal_executions:
-            raise GTCPreconditionError(expected="non-empty vertical loop")
-        result = self.generic_visit(node, **kwargs)
-        horizontal_executions = [result.horizontal_executions[0]]
-        accesses = AccessCollector.apply(horizontal_executions[-1])
-
-        def ij_offsets(
-            offsets: Dict[str, Set[Tuple[int, int, int]]]
-        ) -> Dict[str, Set[Tuple[int, int]]]:
-            return {
-                field: {o[:2] for o in field_offsets} for field, field_offsets in offsets.items()
-            }
-
-        previous_reads = ij_offsets(accesses.read_offsets())
-        previous_writes = ij_offsets(accesses.write_offsets())
-        for horizontal_execution in result.horizontal_executions[1:]:
-            accesses = AccessCollector.apply(horizontal_execution)
-            current_reads = ij_offsets(accesses.read_offsets())
-            current_writes = ij_offsets(accesses.write_offsets())
-
-            conflicting = {
-                field
-                for field, offsets in current_reads.items()
-                if field in previous_writes and offsets ^ previous_writes[field]
-            } | {
-                field
-                for field, offsets in current_writes.items()
-                if field in previous_reads
-                and any(o[:2] != (0, 0) for o in offsets ^ previous_reads[field])
-            }
-            if not conflicting:
-                horizontal_executions[-1].body += horizontal_execution.body
-                for field, writes in current_writes.items():
-                    previous_writes.setdefault(field, set()).update(writes)
-                for field, reads in current_reads.items():
-                    previous_reads.setdefault(field, set()).update(reads)
-            else:
-                horizontal_executions.append(horizontal_execution)
-                previous_writes = current_writes
-                previous_reads = current_reads
-        result.horizontal_executions = horizontal_executions
-        if len(result.horizontal_executions) > len(node.horizontal_executions):
-            raise GTCPostconditionError(
-                expected="the number of horizontal executions is equal or smaller than before"
-            )
-        return result
 
 
 @dataclass
@@ -125,6 +66,7 @@ class OnTheFlyMerging(NodeTranslator):
         horizontal_executions: List[oir.HorizontalExecution],
         symtable: Dict[str, Any],
         new_symbol_name: Callable[[str], str],
+        protected_fields: Set[str],
     ) -> List[oir.HorizontalExecution]:
         """Recursively merge horizontal executions.
 
@@ -146,6 +88,9 @@ class OnTheFlyMerging(NodeTranslator):
         def first_has_large_body() -> bool:
             return len(first.body) > self.max_horizontal_execution_body_size
 
+        def first_writes_protected() -> bool:
+            return bool(protected_fields & first_accesses.write_fields())
+
         def first_has_expensive_function_call() -> bool:
             if self.allow_expensive_function_duplication:
                 return False
@@ -166,10 +111,11 @@ class OnTheFlyMerging(NodeTranslator):
 
         if (
             first_fields_rewritten_later()
+            or first_writes_protected()
             or first_has_large_body()
             or first_has_expensive_function_call()
         ):
-            return [first] + self._merge(others, symtable, new_symbol_name)
+            return [first] + self._merge(others, symtable, new_symbol_name, protected_fields)
 
         writes = first_accesses.write_fields()
         others_otf = []
@@ -209,15 +155,24 @@ class OnTheFlyMerging(NodeTranslator):
                 )
             others_otf.append(merged)
 
-        return self._merge(others_otf, symtable, new_symbol_name)
+        return self._merge(others_otf, symtable, new_symbol_name, protected_fields)
 
     def visit_VerticalLoopSection(
         self, node: oir.VerticalLoopSection, **kwargs: Any
     ) -> oir.VerticalLoopSection:
-        return oir.VerticalLoopSection(
-            interval=node.interval,
-            horizontal_executions=self._merge(node.horizontal_executions, **kwargs),
-        )
+
+        last_vls = None
+        next_vls = node
+        applied = True
+        while applied:
+            last_vls = next_vls
+            next_vls = oir.VerticalLoopSection(
+                interval=last_vls.interval,
+                horizontal_executions=self._merge(last_vls.horizontal_executions, **kwargs),
+            )
+            applied = len(next_vls.horizontal_executions) < len(last_vls.horizontal_executions)
+
+        return next_vls
 
     def visit_VerticalLoop(self, node: oir.VerticalLoop, **kwargs: Any) -> oir.VerticalLoop:
         if node.loop_order != common.LoopOrder.PARALLEL:
@@ -231,12 +186,21 @@ class OnTheFlyMerging(NodeTranslator):
         )
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs: Any) -> oir.Stencil:
-        vertical_loops = self.visit(
-            node.vertical_loops,
-            symtable=node.symtable_,
-            new_symbol_name=symbol_name_creator(set(node.symtable_)),
-            **kwargs,
-        )
+        vertical_loops: List[oir.VerticalLoop] = []
+        protected_fields = set(n.name for n in node.params)
+        for vl in reversed(node.vertical_loops):
+            vertical_loops.insert(
+                0,
+                self.visit(
+                    vl,
+                    symtable=node.symtable_,
+                    new_symbol_name=symbol_name_creator(set(node.symtable_)),
+                    protected_fields=protected_fields,
+                    **kwargs,
+                ),
+            )
+            access_collection = AccessCollector.apply(vl)
+            protected_fields |= access_collection.fields()
         accessed = AccessCollector.apply(vertical_loops).fields()
         return oir.Stencil(
             name=node.name,

--- a/src/gtc/passes/oir_pipeline.py
+++ b/src/gtc/passes/oir_pipeline.py
@@ -28,7 +28,7 @@ from gtc.passes.oir_optimizations.caches import (
     PruneKCacheFills,
     PruneKCacheFlushes,
 )
-from gtc.passes.oir_optimizations.horizontal_execution_merging import GreedyMerging, OnTheFlyMerging
+from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMerging
 from gtc.passes.oir_optimizations.inlining import MaskInlining
 from gtc.passes.oir_optimizations.mask_stmt_merging import MaskStmtMerging
 from gtc.passes.oir_optimizations.pruning import NoFieldAccessPruning
@@ -64,7 +64,6 @@ class OirPipeline:
     def steps(self) -> Sequence[PASS_T]:
         return [
             graph_merge_horizontal_executions,
-            GreedyMerging,
             AdjacentLoopMerging,
             LocalTemporariesToScalars,
             WriteBeforeReadTemporariesToScalars,

--- a/tests/test_unittest/test_gtc/test_oir_pipeline.py
+++ b/tests/test_unittest/test_gtc/test_oir_pipeline.py
@@ -1,4 +1,5 @@
-from gtc.passes.oir_optimizations.horizontal_execution_merging import GreedyMerging, OnTheFlyMerging
+from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMerging
+from gtc.passes.oir_optimizations.vertical_loop_merging import AdjacentLoopMerging
 from gtc.passes.oir_pipeline import OirPipeline, hash_step
 
 from .oir_utils import StencilFactory
@@ -15,10 +16,10 @@ def test_no_skipping():
 
 def test_skip_one():
     pipeline = OirPipeline(StencilFactory())
-    pipeline.full(skip=[GreedyMerging])
+    pipeline.full(skip=[AdjacentLoopMerging])
 
     steps = tuple(hash_step(i) for i in pipeline.steps())
-    skipped = tuple(i for i in steps if i != hash_step(GreedyMerging))
+    skipped = tuple(i for i in steps if i != hash_step(AdjacentLoopMerging))
     wrong_skipped = tuple(i for i in steps if i != hash_step(OnTheFlyMerging))
 
     assert steps not in pipeline._cache

--- a/tests/test_unittest/test_gtc/test_passes/test_dace_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_dace_horizontal_execution_merging.py
@@ -14,13 +14,20 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from gtc import common
 from gtc.passes.oir_dace_optimizations.api import optimize_horizontal_executions
-from gtc.passes.oir_dace_optimizations.horizontal_execution_merging import GraphMerging
+from gtc.passes.oir_dace_optimizations.horizontal_execution_merging import (
+    GraphMerging,
+    graph_merge_horizontal_executions,
+)
 
 from ..oir_utils import (
     AssignStmtFactory,
+    FieldAccessFactory,
     HorizontalExecutionFactory,
+    NativeFuncCallFactory,
     StencilFactory,
+    TemporaryFactory,
     VerticalLoopSectionFactory,
 )
 
@@ -126,3 +133,62 @@ def test_nonzero_extent_merging():
     assert transformed.horizontal_executions[0].body == sum(
         (he.body for he in testee.horizontal_executions), []
     )
+
+
+def test_different_iteration_spaces_param():
+    # need three HE since only a read-write dependency would not be allowed to merge anyways due
+    # to the read with offset. The interesting part is to enforce that the first two are not
+    # merged.
+    testee = StencilFactory(
+        vertical_loops__0__sections__0=VerticalLoopSectionFactory(
+            horizontal_executions=[
+                HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="api1")]),
+                HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="api2")]),
+                HorizontalExecutionFactory(
+                    body__0=AssignStmtFactory(
+                        right=NativeFuncCallFactory(
+                            func=common.NativeFunction.MIN,
+                            args=[
+                                FieldAccessFactory(name="api1", offset__i=1),
+                                FieldAccessFactory(name="api2", offset__j=1),
+                            ],
+                        )
+                    )
+                ),
+            ]
+        )
+    )
+
+    transformed = graph_merge_horizontal_executions(testee)
+    transformed_hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
+    assert len(transformed_hexecs) == 3
+
+
+def test_different_iteration_spaces_temporary():
+    # need three HE since only a read-write dependency would not be allowed to merge anyways due
+    # to the read with offset. The interesting part is to enforce that the first two are not
+    # merged.
+    testee = StencilFactory(
+        vertical_loops__0__sections__0=VerticalLoopSectionFactory(
+            horizontal_executions=[
+                HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp1")]),
+                HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp2")]),
+                HorizontalExecutionFactory(
+                    body__0=AssignStmtFactory(
+                        right=NativeFuncCallFactory(
+                            func=common.NativeFunction.MIN,
+                            args=[
+                                FieldAccessFactory(name="tmp1", offset__i=1),
+                                FieldAccessFactory(name="tmp2", offset__j=1),
+                            ],
+                        )
+                    )
+                ),
+            ]
+        ),
+        declarations=[TemporaryFactory(name="tmp1"), TemporaryFactory(name="tmp2")],
+    )
+
+    transformed = graph_merge_horizontal_executions(testee)
+    transformed_hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
+    assert len(transformed_hexecs) == 2


### PR DESCRIPTION
## Description

Inquiries into python overhead for newer GPU lead to the discovery of an efficient way to collect memory information & ptr when doing the binding. Use `__array_interface__` on Numpy-like object is slower than passing down to C++ the `__array_struct__` which contains already all the information required. Because the computation has a lower lifetime than it's inputs, a ptr-copy only strategy can be used.

Changes:
- Change `bindings.cpp.in` in legacy toolchain
- Change `module` generation to pass down the `__array_struct__` for fields.

Tested on fv3core `gtx86` and `gtcuda`

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


